### PR TITLE
Make MCP server work for Receipts, Invoices, Purchase orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ A Model Context Protocol (MCP) server implementation that integrates with Veryfi
 
 ## Setup
 
+### Get your Veryfi username, client_id, and api key
+Log into [https://app.veryfi.com](https://app.veryfi.com), then navigate to [https://app.veryfi.com/api/settings/keys/]("https://app.veryfi.com/api/settings/keys/)
+
+
+
 ### With Claude Desktop
 
-Modify claude_desktop_config.json to include this
+Modify claude_desktop_config.json to include this:
+
+Do not set environment variables here. It will cause confusion if the enviroment
+variables used by the MCP server differ from those used by your other code.
+
+Instead, setting them in your execution environmont or using a .env file.
 
 ```
 {
@@ -22,16 +32,12 @@ Modify claude_desktop_config.json to include this
                 "run",
                 "src/server.py"
             ],
-            "env": {
-                "VERYFI_CLIENT_ID": "...",
-                "VERYFI_API_TOKEN": "..."
-            }
+            "env": {}
         }
     }
 }
 ```
 
-In Claude, you can simply prompt with `process document and parameters`
 
 ## Development Setup
 
@@ -41,9 +47,20 @@ In Claude, you can simply prompt with `process document and parameters`
 2. Create a `.env` file with the following variables:
 
    ```bash
-   VERYFI_CLIENT_ID=your_client_id
-   VERYFI_API_TOKEN=your_api_token
+   VERYFI_CLIENT_ID="veryfi-client-id-goes-here_client_id"
+   VERYFI_USERNAME="veryfi-username-goes-here"
+   VERYFI_API_KEY="veryfi-api-key-goes-here"
    ```
+
+Alternatively, you can set your environment variables
+in your execution environment. For example, on a Mac,
+append this to your ~/.zprofile
+```bash
+export VERYFI_CLIENT_ID="veryfi-client-id-goes-here_client_id"
+export VERYFI_USERNAME="veryfi-username-goes-here"
+export VERYFI_API_KEY="veryfi-api-key-goes-here"
+```
+
 
 3. Install dependencies:
 

--- a/src/server.py
+++ b/src/server.py
@@ -1,40 +1,87 @@
 import asyncio
+import base64
 import logging
 import os
+from pathlib import Path
 
 import httpx
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
+from validate_credentials import check_veryfi_credentials
+
 load_dotenv()
 
+# Get Veryfi credentials from environment
 VERYFI_CLIENT_ID = os.getenv("VERYFI_CLIENT_ID")
-VERYFI_API_TOKEN = os.getenv("VERYFI_API_TOKEN")
-VERYFI_API_URL = "https://api.veryfi.com/api/v8/partner/"
+VERYFI_USERNAME = os.getenv("VERYFI_USERNAME")
+VERYFI_API_KEY = os.getenv("VERYFI_API_KEY")
+VERYFI_API_URL = "https://api.veryfi.com/api/v8/partner/documents"
+
+
 server = FastMCP(name="veryfi-mcp")
-AUTH_HEADERS = {
-    "client-id": VERYFI_CLIENT_ID,
-    "authorization": VERYFI_API_TOKEN,
-}
 
 
 @server.tool(
     name="process_document",
-    description="Upload a document to Veryfi and extract data.",
+    description="Upload a document to Veryfi and extract data from receipts, invoices, etc.",
 )
-async def process_document(**parameters) -> dict:
-    """Upload a document to Veryfi and extract data."""
-    logging.info(f"Processing with parameters: {parameters['parameters']}")
-    document_type = parameters["parameters"].pop("document_type", "documents")
+async def process_document(file_path: str, document_type: str = "receipt") -> dict:
+    """Upload a document to Veryfi and extract data.
+
+    Args:
+        file_path: Path to the document file to process
+        document_type: Type of document (default: "receipt")
+
+    Returns:
+        dict: Extracted data from Veryfi API
+    """
+    # Check credentials before processing
+    error_message = check_veryfi_credentials()
+    if error_message:
+        raise ValueError(error_message)
+
+    logging.info(f"Processing document: {file_path}")
+
+    # Read and encode file
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    with open(path, "rb") as file:
+        content_bytes = file.read()
+
+    file_data = base64.b64encode(content_bytes).decode("utf-8")
+
+    # Prepare payload
+    payload = {
+        "categories": [],
+        "tags": [],
+        "compute": True,
+        "document_type": document_type,
+        "file_data": file_data,
+    }
+
+    # Prepare headers with correct authentication format
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "CLIENT-ID": VERYFI_CLIENT_ID,
+        "AUTHORIZATION": f"apikey {VERYFI_USERNAME}:{VERYFI_API_KEY}",
+    }
+
+    # Make request
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            f"{VERYFI_API_URL}/{document_type}",
-            headers=AUTH_HEADERS,
-            json=parameters["parameters"],
-            timeout=120,
+            VERYFI_API_URL,
+            json=payload,
+            headers=headers,
+            timeout=120.0,
         )
         response.raise_for_status()
-        return response.json()
+        result = response.json()
+        logging.info(f"Successfully processed document: {path.name}")
+        return result
 
 
 # @server.resource("data://documents", mime_type="application/json")

--- a/src/server.py
+++ b/src/server.py
@@ -19,22 +19,36 @@ VERYFI_API_KEY = os.getenv("VERYFI_API_KEY")
 VERYFI_API_URL = "https://api.veryfi.com/api/v8/partner/documents"
 
 
-server = FastMCP(name="veryfi-mcp")
+server = FastMCP(
+    name="veryfi-mcp",
+    instructions="""Veryfi is a service to extract data from financial documents. It is fast, accurate, and secure. Veryfi has many endpoints. The "documents" endpoint is a misnomer. It works with receipts, invoices, and purchase orders. For other document types, it's imperative to use Veryfi's other API endpoints. The following document types have endpoints with a dedicated ML model and schema:
+- bank checks
+- bank statements
+- W2s
+- W8-BEN-E
+- W9s
+- business cards""",
+)
 
 
 @server.tool(
     name="process_document",
-    description="Upload a document to Veryfi and extract data from receipts, invoices, etc.",
+    description=(
+        "Extract structured data from images of receipts, invoices, and purchase orders using Veryfi's OCR technology. "
+        "Returns JSON with vendor name, amounts, dates, line items, taxes, and other transaction details. "
+        "SUPPORTED: receipts, invoices, purchase orders. "
+        "NOT SUPPORTED: bank checks, bank statements, W2s, W8-BEN-E, W9s, business cards - users must use Veryfi API directly for these."
+    ),
 )
 async def process_document(file_path: str, document_type: str = "receipt") -> dict:
-    """Upload a document to Veryfi and extract data.
+    """Upload a document to Veryfi and extract structured data.
 
     Args:
-        file_path: Path to the document file to process
-        document_type: Type of document (default: "receipt")
+        file_path: Path to the document image file to process (JPG, PNG, PDF, etc.)
+        document_type: Type of document - "receipt", "invoice", or "purchase_order" (default: "receipt")
 
     Returns:
-        dict: Extracted data from Veryfi API
+        dict: Extracted data including vendor, total, date, line items, taxes, etc. in JSON format
     """
     # Check credentials before processing
     error_message = check_veryfi_credentials()

--- a/src/validate_credentials.py
+++ b/src/validate_credentials.py
@@ -1,0 +1,104 @@
+import os
+import platform
+from textwrap import dedent
+
+
+def check_veryfi_credentials():
+    """Check if Veryfi credentials are properly set and return detailed error message if not."""
+    missing_vars = []
+    empty_vars = []
+
+    # Check each required variable
+    for var_name in ["VERYFI_CLIENT_ID", "VERYFI_USERNAME", "VERYFI_API_KEY"]:
+        value = os.getenv(var_name)
+        if value is None:
+            missing_vars.append(var_name)
+        elif value.strip() == "":
+            empty_vars.append(var_name)
+
+    if not missing_vars and not empty_vars:
+        return None  # All credentials are properly set
+
+    # Build error message parts
+    error_parts = []
+
+    # Header
+    error_parts.append("## Missing Veryfi Credentials\n")
+
+    # List missing/empty variables
+    if missing_vars or empty_vars:
+        error_parts.append("The following environment variables are required but not properly set:\n")
+
+        for var in missing_vars:
+            error_parts.append(f"• **{var}** - Not found in environment")
+
+        for var in empty_vars:
+            error_parts.append(f"• **{var}** - Set but empty")
+
+    # Add debugging help section
+    debug_code = "\n".join(
+        [
+            "import os",
+            *[
+                f"print('{var}:', os.environ.get('{var}', 'Not set'))"
+                for var in ["VERYFI_CLIENT_ID", "VERYFI_USERNAME", "VERYFI_API_KEY"]
+            ],
+        ]
+    )
+
+    error_parts.extend(
+        [
+            "\n### Debug your current environment\n",
+            "You can check your current environment variables by running:\n",
+            f"```python\n{debug_code}\n```\n",
+        ]
+    )
+
+    # Add setup instructions
+    error_parts.extend(
+        [
+            "### How to fix this\n",
+            "These values can be found in the Veryfi Hub. Visit https://app.veryfi.com, ",
+            "and sign into your account. Next, navigate to https://app.veryfi.com/api/settings/keys/\n",
+        ]
+    )
+
+    # Option 1: .env file
+    env_file_content = dedent(
+        """
+        VERYFI_CLIENT_ID="your-client-id-here"
+        VERYFI_USERNAME="your-username-here"
+        VERYFI_API_KEY="your-api-key-here"
+    """
+    ).strip()
+
+    # Explain environment variable precedence
+    env_explanation = dedent(
+        """
+        #### Understand how env variables are set
+
+        The Veryfi MCP uses dotenv. It will look for a file, .env,
+        in the folder containing the MCP server, and in all ancestor folders.
+        If your environment variables are set here, they overwrite all other env variables.
+
+        Your AI agent's setting will overwrite env variables set in your execution environment.
+        For example, Claude variables are set in ~/.claude.json.
+        Since you'll want to use environment variables or .env files to call Veryfi's API from your
+        code, for most use cases you should not set the environment variables here.
+
+        You can set your environment variables using other methods. For example, on a mac
+        you can set them by editing your .zprofile or .bashrc file.
+        IMPORTANT: If you reset variables this way, make sure to quit and restart VSCode / Cursor,
+        and to create a new session if you're using a CLI tool like Claude Code.
+        This means that you should not set the environment variables in your agent settings.
+        """
+    ).strip()
+
+    error_parts.extend(
+        [
+            "\n" + env_explanation,
+            f"```\n{env_file_content}\n```\n",
+        ]
+    )
+
+    return "\n".join(error_parts)


### PR DESCRIPTION
The previous MCP server would not work for user who followed instructions on the readme.

Specifically, users will to know to how to construct and API token by concatenating a username to a api key.

I've update the code to work. 

In addition, I added code that provides helpful debugging context should the user try to call the MCP server without setting up their environment variables.

I removed environment variables from the agent-specifying settings ("mcpServers": {...}) the reason is that the user needs to set environment variables in either the .env file or their environment (.zprofile on Mac). Setting them in two places causes confusion and, worse yet, slows down new users. 

There are many features this does _not_ yet supported, and lots of more work to do. But, at least it works now.